### PR TITLE
Fix RBAC Configuration for AKS Cluster

### DIFF
--- a/modules/aks/main.tf
+++ b/modules/aks/main.tf
@@ -43,8 +43,8 @@ resource "azurerm_kubernetes_cluster" "main" {
     type = "SystemAssigned"
   }
 
-  # RBAC is enabled by default in Azure Provider v3.0+
-  # No explicit configuration needed
+  # Enable RBAC explicitly
+  role_based_access_control_enabled = true
 
   # Enable logging with explicit configuration
   oms_agent {


### PR DESCRIPTION
This PR fixes the RBAC configuration for AKS clusters to resolve tfsec security warnings.

## Changes Made
- Added explicit  configuration
- This ensures proper role-based access control is enabled for all AKS clusters
- Resolves tfsec warning: azure-container-use-rbac-permissions

## Security Impact
- Improves security posture by ensuring RBAC is properly configured
- Follows Azure security best practices
- Addresses potential security vulnerabilities

## Testing
- This change will be tested by the Static Analysis workflow
- tfsec should now pass without RBAC-related warnings