### PR TITLE
Fix Terraform Authentication in GitHub Actions

### DIFF
--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -39,4 +39,9 @@ jobs:
 
       - name: Terraform Apply
         run: terraform apply -auto-approve
-        working-directory: environments/${{ matrix.environment }} 
+        working-directory: environments/${{ matrix.environment }}
+        env:
+          ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          ARM_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+          ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }} 


### PR DESCRIPTION
This PR fixes the Terraform authentication issue in GitHub Actions by adding the necessary environment variables to the terraform-apply workflow.

## Problem
Terraform was failing with 'Authenticating using the Azure CLI is only supported as a User (not a Service Principal)' error.

## Solution
Added environment variables to pass Azure Service Principal credentials to Terraform:
- ARM_CLIENT_ID
- ARM_CLIENT_SECRET  
- ARM_SUBSCRIPTION_ID
- ARM_TENANT_ID

This ensures Terraform uses Service Principal authentication instead of Azure CLI authentication.