### PR TITLE
Fix GitHub Actions Authentication Conflict

### DIFF
--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -28,11 +28,6 @@ jobs:
         with:
           terraform_version: "1.5.0"
 
-      - name: Azure Login
-        uses: azure/login@v1
-        with:
-          creds: ${{ secrets.AZURE_CREDENTIALS }}
-
       - name: Terraform Init
         run: terraform init
         working-directory: environments/${{ matrix.environment }}

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -33,14 +33,14 @@ jobs:
         with:
           tflint_version: v0.44.1
 
-      - name: Azure Login
-        uses: azure/login@v1
-        with:
-          creds: ${{ secrets.AZURE_CREDENTIALS }}
-
       - name: Terraform Init
         run: terraform init
         working-directory: environments/${{ matrix.environment }}
+        env:
+          ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          ARM_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+          ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
 
       - name: TFLint
         run: |
@@ -51,6 +51,11 @@ jobs:
       - name: Terraform Plan
         run: terraform plan -out=tfplan
         working-directory: environments/${{ matrix.environment }}
+        env:
+          ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          ARM_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+          ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
 
       - name: Upload Terraform Plan
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
This PR fixes the authentication conflict in GitHub Actions by removing the Azure Login Action and using only Terraform environment variables.

## Problem
GitHub Actions was using both Azure Login Action (AZURE_CREDENTIALS) and Terraform environment variables (ARM_CLIENT_ID, etc.), causing authentication conflicts.

## Solution
- Removed Azure Login Action from terraform-apply.yml and terraform-plan.yml
- Using only Terraform environment variables for authentication
- This ensures consistent Service Principal authentication throughout the workflow

## Changes Made
- Removed azure/login@v1 step from terraform-apply.yml
- Removed azure/login@v1 step from terraform-plan.yml
- Added environment variables to terraform-plan.yml terraform plan step
- This eliminates authentication conflicts and ensures Terraform uses Service Principal authentication consistently