### PR TITLE
Fix Kubernetes Dependencies

### DIFF
--- a/modules/weather-app/main.tf
+++ b/modules/weather-app/main.tf
@@ -51,6 +51,8 @@ provider "kubernetes" {
 
 # Kubernetes Namespace
 resource "kubernetes_namespace" "weather_app" {
+  depends_on = [azurerm_container_registry.main, azurerm_redis_cache.main]
+  
   metadata {
     name = "weather-app"
     labels = {


### PR DESCRIPTION
This PR fixes the Kubernetes dependency issue that was causing connection errors.

## Problem
Kubernetes resources were being created before the AKS cluster was fully ready, causing connection errors.

## Solution
- Added proper dependencies to ensure Azure resources (ACR, Redis) are created before Kubernetes resources
- This ensures the AKS cluster has time to fully initialize before Terraform tries to create Kubernetes resources

## Expected Result
- GitHub Actions should complete successfully
- All resources should be deployed without connection errors