### PR TITLE
Fix Static Analysis Workflow

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -40,8 +40,8 @@ jobs:
           for dir in environments/*/; do
             if [ -f "$dir/main.tf" ]; then
               echo "Validating $dir"
-              terraform init -backend=false $dir
-              terraform validate $dir
+              terraform init -backend=false -chdir="$dir"
+              terraform validate -chdir="$dir"
             fi
           done
 


### PR DESCRIPTION
This PR fixes the static analysis workflow Terraform validation command.

## Changes
- Fixed 	erraform init and 	erraform validate commands in .github/workflows/static-analysis.yml
- Changed from using directory as argument to using -chdir flag
- This resolves the 'Too many command line arguments' error

## Expected Result
- Static analysis workflow should now run successfully
- Terraform validation should work correctly for all environments