### PR TITLE
Fix Static Analysis Authentication

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -44,6 +44,11 @@ jobs:
               terraform validate -chdir="$dir"
             fi
           done
+        env:
+          ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          ARM_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+          ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
 
       - name: TFLint
         run: |


### PR DESCRIPTION
This PR fixes the static analysis workflow authentication issue.

## Problem
- Static analysis workflow failed because Terraform validation requires Azure authentication
- The workflow was trying to initialize Terraform without proper Azure credentials

## Solution
- Added Azure environment variables to the Terraform Validate step
- This allows Terraform to authenticate with Azure for backend initialization

## Changes
- Added nv block to Terraform Validate step with:
  - ARM_CLIENT_ID
  - ARM_CLIENT_SECRET  
  - ARM_SUBSCRIPTION_ID
  - ARM_TENANT_ID

## Expected Result
- Static analysis workflow should now run successfully
- Terraform validation should work with proper Azure authentication