### PR TITLE
Fix Static Analysis Backend Issue

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -44,11 +44,6 @@ jobs:
               terraform validate -chdir="$dir"
             fi
           done
-        env:
-          ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
-          ARM_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
-          ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-          ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
 
       - name: TFLint
         run: |


### PR DESCRIPTION
This PR fixes the static analysis workflow by removing Azure authentication dependency.

## Problem
- Static analysis workflow was trying to authenticate with Azure backend
- This caused authentication failures in CI/CD environment
- Static analysis should not require actual Azure connectivity

## Solution
- Removed Azure environment variables from Terraform Validate step
- Using -backend=false flag to skip backend initialization
- This allows Terraform validation without Azure authentication

## Changes
- Removed nv block with Azure credentials from Terraform Validate step
- Kept -backend=false flag to prevent backend initialization
- Static analysis now focuses on syntax and configuration validation only

## Expected Result
- Static analysis workflow should run successfully without Azure authentication
- Terraform validation will work for syntax checking only
- No dependency on Azure credentials for static analysis