### PR TITLE
Fix State Drift in Prod Environment

### DIFF
--- a/cleanup-prod-resources.sh
+++ b/cleanup-prod-resources.sh
@@ -22,40 +22,34 @@ echo "🗑️  Removing Network Security Rules..."
 az network nsg rule delete \
     --resource-group "$RESOURCE_GROUP" \
     --nsg-name "$NSG_NAME" \
-    --name "allow-https" \
-    --yes || echo "⚠️  allow-https rule not found"
+    --name "allow-https" || echo "⚠️  allow-https rule not found"
 
 az network nsg rule delete \
     --resource-group "$RESOURCE_GROUP" \
     --nsg-name "$NSG_NAME" \
-    --name "allow-http" \
-    --yes || echo "⚠️  allow-http rule not found"
+    --name "allow-http" || echo "⚠️  allow-http rule not found"
 
 az network nsg rule delete \
     --resource-group "$RESOURCE_GROUP" \
     --nsg-name "$NSG_NAME" \
-    --name "allow-ssh" \
-    --yes || echo "⚠️  allow-ssh rule not found"
+    --name "allow-ssh" || echo "⚠️  allow-ssh rule not found"
 
 az network nsg rule delete \
     --resource-group "$RESOURCE_GROUP" \
     --nsg-name "$NSG_NAME" \
-    --name "allow-lb-health-check" \
-    --yes || echo "⚠️  allow-lb-health-check rule not found"
+    --name "allow-lb-health-check" || echo "⚠️  allow-lb-health-check rule not found"
 
 az network nsg rule delete \
     --resource-group "$RESOURCE_GROUP" \
     --nsg-name "$NSG_NAME" \
-    --name "deny-all-inbound" \
-    --yes || echo "⚠️  deny-all-inbound rule not found"
+    --name "deny-all-inbound" || echo "⚠️  deny-all-inbound rule not found"
 
 echo "🗑️  Removing Log Analytics Workspace..."
 
 # Remove Log Analytics Workspace
 az monitor log-analytics workspace delete \
     --resource-group "$RESOURCE_GROUP" \
-    --workspace-name "prod-aks-logs" \
-    --yes || echo "⚠️  prod-aks-logs workspace not found"
+    --workspace-name "prod-aks-logs" || echo "⚠️  prod-aks-logs workspace not found"
 
 echo "✅ Cleanup completed!"
 echo "🎯 Next step: Create a new PR to trigger Terraform Apply" 

--- a/cleanup-prod-resources.sh
+++ b/cleanup-prod-resources.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+# Clean up existing Azure resources in prod environment
+# This script removes resources that are causing state drift
+
+set -e
+
+echo "🧹 Cleaning up existing Azure resources in prod environment..."
+
+# Set environment variables for Azure authentication
+export ARM_CLIENT_ID="$AZURE_CLIENT_ID"
+export ARM_CLIENT_SECRET="$AZURE_CLIENT_SECRET"
+export ARM_SUBSCRIPTION_ID="$AZURE_SUBSCRIPTION_ID"
+export ARM_TENANT_ID="$AZURE_TENANT_ID"
+
+RESOURCE_GROUP="cst8918-final-project-group-1"
+NSG_NAME="prod-nsg"
+
+echo "🗑️  Removing Network Security Rules..."
+
+# Remove NSG rules
+az network nsg rule delete \
+    --resource-group "$RESOURCE_GROUP" \
+    --nsg-name "$NSG_NAME" \
+    --name "allow-https" \
+    --yes || echo "⚠️  allow-https rule not found"
+
+az network nsg rule delete \
+    --resource-group "$RESOURCE_GROUP" \
+    --nsg-name "$NSG_NAME" \
+    --name "allow-http" \
+    --yes || echo "⚠️  allow-http rule not found"
+
+az network nsg rule delete \
+    --resource-group "$RESOURCE_GROUP" \
+    --nsg-name "$NSG_NAME" \
+    --name "allow-ssh" \
+    --yes || echo "⚠️  allow-ssh rule not found"
+
+az network nsg rule delete \
+    --resource-group "$RESOURCE_GROUP" \
+    --nsg-name "$NSG_NAME" \
+    --name "allow-lb-health-check" \
+    --yes || echo "⚠️  allow-lb-health-check rule not found"
+
+az network nsg rule delete \
+    --resource-group "$RESOURCE_GROUP" \
+    --nsg-name "$NSG_NAME" \
+    --name "deny-all-inbound" \
+    --yes || echo "⚠️  deny-all-inbound rule not found"
+
+echo "🗑️  Removing Log Analytics Workspace..."
+
+# Remove Log Analytics Workspace
+az monitor log-analytics workspace delete \
+    --resource-group "$RESOURCE_GROUP" \
+    --workspace-name "prod-aks-logs" \
+    --yes || echo "⚠️  prod-aks-logs workspace not found"
+
+echo "✅ Cleanup completed!"
+echo "🎯 Next step: Create a new PR to trigger Terraform Apply" 

--- a/import-existing-resources.sh
+++ b/import-existing-resources.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+# Import existing Azure resources to Terraform state
+# This script handles state drift by importing existing resources
+
+set -e
+
+echo "🔧 Importing existing Azure resources to Terraform state..."
+
+# Set environment variables for Azure authentication
+export ARM_CLIENT_ID="$AZURE_CLIENT_ID"
+export ARM_CLIENT_SECRET="$AZURE_CLIENT_SECRET"
+export ARM_SUBSCRIPTION_ID="$AZURE_SUBSCRIPTION_ID"
+export ARM_TENANT_ID="$AZURE_TENANT_ID"
+
+# Function to import resource
+import_resource() {
+    local resource_id="$1"
+    local terraform_address="$2"
+    local environment="$3"
+    
+    echo "📥 Importing $terraform_address..."
+    cd "environments/$environment"
+    
+    terraform import "$terraform_address" "$resource_id" || {
+        echo "⚠️  Failed to import $terraform_address, continuing..."
+    }
+    
+    cd ../..
+}
+
+# Import Log Analytics Workspace for prod environment
+echo "📊 Importing Log Analytics Workspace..."
+import_resource \
+    "/subscriptions/***/resourceGroups/cst8918-final-project-group-1/providers/Microsoft.OperationalInsights/workspaces/prod-aks-logs" \
+    "module.aks.azurerm_log_analytics_workspace.main" \
+    "prod"
+
+# Import Network Security Rules for prod environment
+echo "🔒 Importing Network Security Rules..."
+
+# allow-https rule
+import_resource \
+    "/subscriptions/***/resourceGroups/cst8918-final-project-group-1/providers/Microsoft.Network/networkSecurityGroups/prod-nsg/securityRules/allow-https" \
+    "module.network.azurerm_network_security_rule.allow_https" \
+    "prod"
+
+# allow-http rule
+import_resource \
+    "/subscriptions/***/resourceGroups/cst8918-final-project-group-1/providers/Microsoft.Network/networkSecurityGroups/prod-nsg/securityRules/allow-http" \
+    "module.network.azurerm_network_security_rule.allow_http" \
+    "prod"
+
+# allow-ssh rule
+import_resource \
+    "/subscriptions/***/resourceGroups/cst8918-final-project-group-1/providers/Microsoft.Network/networkSecurityGroups/prod-nsg/securityRules/allow-ssh" \
+    "module.network.azurerm_network_security_rule.allow_ssh" \
+    "prod"
+
+# allow-lb-health-check rule
+import_resource \
+    "/subscriptions/***/resourceGroups/cst8918-final-project-group-1/providers/Microsoft.Network/networkSecurityGroups/prod-nsg/securityRules/allow-lb-health-check" \
+    "module.network.azurerm_network_security_rule.allow_lb_health_check" \
+    "prod"
+
+# deny-all-inbound rule
+import_resource \
+    "/subscriptions/***/resourceGroups/cst8918-final-project-group-1/providers/Microsoft.Network/networkSecurityGroups/prod-nsg/securityRules/deny-all-inbound" \
+    "module.network.azurerm_network_security_rule.deny_all_inbound" \
+    "prod"
+
+echo "✅ Import completed!"
+echo "🎯 Next step: Create a new PR to trigger Terraform Apply" 


### PR DESCRIPTION
This PR addresses the state drift issue in the prod environment.

## Problem
- Resources exist in Azure but are not tracked in Terraform state
- This causes 'resource already exists' errors during terraform apply
- Affects: Log Analytics Workspace and Network Security Rules

## Solution
- Added cleanup script to remove existing resources
- Added import script as alternative approach
- Both scripts handle the state drift issue

## Files Added
- cleanup-prod-resources.sh: Removes existing resources to allow recreation
- import-existing-resources.sh: Imports existing resources into Terraform state

## Next Steps
1. Merge this PR
2. Run cleanup script manually if needed
3. Trigger new Terraform Apply workflow
4. Verify all environments deploy successfully

## Expected Result
- Terraform Apply should succeed for all environments
- No more 'resource already exists' errors
- All Kubernetes resources should be created properly