### PR TITLE
Trigger Terraform Apply after AKS Cluster Restart

### DIFF
--- a/modules/weather-app/README.md
+++ b/modules/weather-app/README.md
@@ -1,0 +1,1 @@
+# Trigger Terraform Apply after AKS cluster restart


### PR DESCRIPTION
This PR triggers a new Terraform Apply workflow after restarting the dev-aks cluster.

## Changes Made
- Restarted dev-aks cluster to fix provisioning state
- dev-aks provisioning state changed from 'Canceled' to 'Succeeded'
- Added trigger file to modules/weather-app/ to ensure workflow runs

## Problem Solved
- dev-aks cluster was in 'Canceled' state causing connection timeouts
- AKS cluster restart resolved the provisioning state issue
- All AKS clusters are now in 'Running' and 'Succeeded' state

## Expected Result
- Terraform Apply workflow should succeed for all environments
- No more AKS connection timeout errors
- All Kubernetes resources should be created properly
- Application should be accessible from external network