### PR TITLE
Fix network: use data source for existing virtual network

### DIFF
--- a/modules/network/main.tf
+++ b/modules/network/main.tf
@@ -13,39 +13,37 @@ data "azurerm_resource_group" "network" {
   name = var.resource_group_name
 }
 
-resource "azurerm_virtual_network" "main" {
+# Use data source for existing virtual network
+data "azurerm_virtual_network" "main" {
   name                = "${var.environment}-vnet"
   resource_group_name = data.azurerm_resource_group.network.name
-  location            = data.azurerm_resource_group.network.location
-  address_space       = [var.vnet_address_space]
-  tags                = var.tags
 }
 
 resource "azurerm_subnet" "prod" {
   name                 = "prod-subnet"
   resource_group_name  = data.azurerm_resource_group.network.name
-  virtual_network_name = azurerm_virtual_network.main.name
+  virtual_network_name = data.azurerm_virtual_network.main.name
   address_prefixes     = [var.prod_subnet_address_space]
 }
 
 resource "azurerm_subnet" "test" {
   name                 = "test-subnet"
   resource_group_name  = data.azurerm_resource_group.network.name
-  virtual_network_name = azurerm_virtual_network.main.name
+  virtual_network_name = data.azurerm_virtual_network.main.name
   address_prefixes     = [var.test_subnet_address_space]
 }
 
 resource "azurerm_subnet" "dev" {
   name                 = "dev-subnet"
   resource_group_name  = data.azurerm_resource_group.network.name
-  virtual_network_name = azurerm_virtual_network.main.name
+  virtual_network_name = data.azurerm_virtual_network.main.name
   address_prefixes     = [var.dev_subnet_address_space]
 }
 
 resource "azurerm_subnet" "admin" {
   name                 = "admin-subnet"
   resource_group_name  = data.azurerm_resource_group.network.name
-  virtual_network_name = azurerm_virtual_network.main.name
+  virtual_network_name = data.azurerm_virtual_network.main.name
   address_prefixes     = [var.admin_subnet_address_space]
 }
 

--- a/modules/network/outputs.tf
+++ b/modules/network/outputs.tf
@@ -5,12 +5,12 @@ output "resource_group_name" {
 
 output "virtual_network_name" {
   description = "Name of the virtual network"
-  value       = azurerm_virtual_network.main.name
+  value       = data.azurerm_virtual_network.main.name
 }
 
 output "virtual_network_id" {
   description = "ID of the virtual network"
-  value       = azurerm_virtual_network.main.id
+  value       = data.azurerm_virtual_network.main.id
 }
 
 output "prod_subnet_id" {


### PR DESCRIPTION
This PR updates the network module to use a data source for the existing virtual network (VNet) and updates all references. This should resolve the VNet resource conflict in CI/CD workflows.