### PR TITLE
Test lock-timeout fix with teammate's suggestions

### DIFF
--- a/.github/workflows/complete-pipeline.yml
+++ b/.github/workflows/complete-pipeline.yml
@@ -112,9 +112,7 @@ jobs:
           cd environments/${{ matrix.environment }}
           terraform init
           
-          # Force unlock any existing locks (in case of stale locks)
-          terraform force-unlock -force || true
-          
+          # Note: Using -lock=false to avoid lock issues
           terraform plan -out=tfplan -lock=false
         env:
           ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
@@ -157,9 +155,10 @@ jobs:
         run: |
           cd environments/${{ matrix.environment }}
           
-          # Force unlock any existing locks (in case of stale locks)
-          terraform force-unlock -force || true
+          # Initialize Terraform to download providers
+          terraform init
           
+          # Note: Using -lock=false to avoid lock issues
           terraform apply -auto-approve -lock=false tfplan
         env:
           ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
@@ -220,9 +219,7 @@ jobs:
           cd environments/${{ matrix.environment }}
           terraform init
           
-          # Force unlock any existing locks (in case of stale locks)
-          terraform force-unlock -force || true
-          
+          # Note: Using -lock=false to avoid lock issues
           terraform plan -detailed-exitcode -lock=false
         env:
           ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}

--- a/.github/workflows/complete-pipeline.yml
+++ b/.github/workflows/complete-pipeline.yml
@@ -112,8 +112,8 @@ jobs:
           cd environments/${{ matrix.environment }}
           terraform init
           
-          # Note: Using -lock=false to avoid lock issues
-          terraform plan -out=tfplan -lock=false
+          # Note: Using -lock-timeout=300s to wait for locks instead of failing immediately
+          terraform plan -out=tfplan -lock-timeout=300s
         env:
           ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
           ARM_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
@@ -158,8 +158,8 @@ jobs:
           # Initialize Terraform to download providers
           terraform init
           
-          # Note: Using -lock=false to avoid lock issues
-          terraform apply -auto-approve -lock=false tfplan
+          # Note: Using -lock-timeout=300s to wait for locks instead of failing immediately
+          terraform apply -auto-approve tfplan -lock-timeout=300s
         env:
           ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
           ARM_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
@@ -219,8 +219,8 @@ jobs:
           cd environments/${{ matrix.environment }}
           terraform init
           
-          # Note: Using -lock=false to avoid lock issues
-          terraform plan -detailed-exitcode -lock=false
+          # Note: Using -lock-timeout=300s to wait for locks instead of failing immediately
+          terraform plan -detailed-exitcode -lock-timeout=300s
         env:
           ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
           ARM_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}

--- a/test-lock-timeout-fix.md
+++ b/test-lock-timeout-fix.md
@@ -1,0 +1,29 @@
+# Test Lock Timeout Fix
+
+This file is created to test the CI/CD pipeline with the latest lock-timeout fixes.
+
+## Recent Fixes Applied
+
+1. **Lock Timeout Implementation**:
+   - Changed from `-lock=false` to `-lock-timeout=300s`
+   - This allows Terraform to wait up to 5 minutes for locks instead of failing immediately
+   - Applied to terraform-plan, terraform-apply, and drift-check jobs
+
+2. **Provider Version Consistency**:
+   - Added `.terraform.lock.hcl` files to git tracking
+   - Removed `.terraform.lock.hcl` from `.gitignore`
+   - Generated lock files with `terraform providers lock -platform=linux_amd64`
+
+3. **Terraform Apply Job Fixes**:
+   - Added `terraform init` to download providers
+   - Removed invalid `terraform force-unlock -force` command
+   - Using `-lock-timeout=300s` for proper lock handling
+
+## Expected Behavior
+- No provider plugin missing errors
+- No invalid force-unlock command errors
+- No provider version inconsistency errors
+- Terraform will wait up to 5 minutes for locks instead of failing immediately
+
+## Test Purpose
+Trigger the workflow to verify the lock-timeout fix is working correctly. 

--- a/test-workflow-trigger.md
+++ b/test-workflow-trigger.md
@@ -1,0 +1,23 @@
+# Test Workflow Trigger
+
+This file is created to test the CI/CD pipeline with the latest fixes.
+
+## Recent Fixes Applied
+
+1. **Provider Version Consistency**:
+   - Added `.terraform.lock.hcl` files to git tracking
+   - Removed `.terraform.lock.hcl` from `.gitignore`
+   - Generated lock files with `terraform providers lock -platform=linux_amd64`
+
+2. **Terraform Apply Job Fixes**:
+   - Added `terraform init` to download providers
+   - Removed invalid `terraform force-unlock -force` command
+   - Using `-lock=false` flag for lock handling
+
+3. **Expected Behavior**:
+   - No provider plugin missing errors
+   - No invalid force-unlock command errors
+   - No provider version inconsistency errors
+
+## Test Purpose
+Trigger the workflow to verify all fixes are working correctly. 


### PR DESCRIPTION
## Test Lock Timeout Fix

This PR tests the latest fixes based on teammate's suggestions:

### **Teammate's Analysis Applied**:
1. **Problem 1**: Fixed \	erraform force-unlock\ usage error (requires LOCK_ID)
2. **Problem 2**: Fixed missing provider plugins by adding \	erraform init\
3. **Solution**: Use \-lock-timeout=300s\ instead of \-lock=false\ to wait for locks instead of failing immediately

### **Changes Made**:
- **terraform-plan**: \	erraform plan -out=tfplan -lock-timeout=300s\
- **terraform-apply**: \	erraform apply -auto-approve tfplan -lock-timeout=300s\
- **drift-check**: \	erraform plan -detailed-exitcode -lock-timeout=300s\

### **Provider Version Consistency**:
- Removed \.terraform.lock.hcl\ from .gitignore
- Added all \.terraform.lock.hcl\ files to git tracking
- Generated lock files with \	erraform providers lock -platform=linux_amd64\

### **Expected Result**:
- No provider plugin missing errors
- No invalid force-unlock command errors  
- No provider version inconsistency errors
- Terraform will wait up to 5 minutes for locks instead of failing immediately

This PR will trigger the workflow to verify all fixes are working correctly.